### PR TITLE
Add cargo fmt and clippy checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test
+
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - run: cargo fmt --check
+      - run: cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
Adds a separate lint job that runs cargo fmt --check and cargo clippy --all-targets with -D warnings. Lint output is deterministic across OSes, so it runs only on Ubuntu in parallel with the cross-OS test matrix.