### PR TITLE
Bump version to 0.2.1 - fix --help formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sumcol"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A command-line tool to sum a column of numbers."

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,10 @@ enum Radix {
 /// Sum a column of numbers from text input.
 ///
 /// Examples:
-///   ls -l | sumcol -f 5
-///   sumcol -f 3 -d : /etc/passwd
+///   ls -l | sumcol -f5
+///
 #[derive(Parser, Debug)]
-#[command(version, about)]
+#[command(version, verbatim_doc_comment)]
 struct Args {
     /// The field to sum. If not specified, uses the full line.
     #[arg(long, short, default_value("0"))]


### PR DESCRIPTION
Use clap's verbatim_doc_comment so the doc comment on Args is preserved verbatim in --help output. Without it, clap fold-wraps multiple lines into a single paragraph and strips indentation, mangling the example section.